### PR TITLE
More Authentication Methods

### DIFF
--- a/lib/bn-ldap-authentication.rb
+++ b/lib/bn-ldap-authentication.rb
@@ -11,14 +11,28 @@ module LdapAuthenticator
     }
 
     def send_ldap_request(user_params, provider_info)
-        ldap = Net::LDAP.new(
-            host: provider_info[:host],
-            port: provider_info[:port],
-            auth: {
+        case provider_info[:auth_method]
+        when 'anonymous'
+            auth = {
+                method: :anonymous
+            }
+        when 'user'
+            auth = {
+                method: :simple,
+                username: provider_info[:uid] + '=' + user_params[:username] + ',' + provider_info[:base],
+                password: user_params[:password]
+            }
+        else
+            auth = {
                 method: :simple,
                 username: provider_info[:bind_dn],
                 password: provider_info[:password]
-            },
+            }
+        end
+        ldap = Net::LDAP.new(
+            host: provider_info[:host],
+            port: provider_info[:port],
+            auth: auth,
             encryption: provider_info[:encryption]
         )
 


### PR DESCRIPTION
In addition to having a global LDAP user allowed to search the LDAP,
this patch enables two additional authentication methods:

- `anonymous` enables an anonymous bind to the LDAP with no password
  being used.

- `user` uses the user's own credentials to search for his data,
  enabling authenticated login to LDAP without the need for a user with
  global read privileges.

The default still remains at using a bind user, allowing for a seamless
upgrade path from the previous version.

This is also the basis for eventually fixing
https://github.com/bigbluebutton/greenlight/issues/1082