### PR TITLE
Allow to set an LDAP filter

### DIFF
--- a/lib/bn-ldap-authentication.rb
+++ b/lib/bn-ldap-authentication.rb
@@ -22,9 +22,14 @@ module LdapAuthenticator
             encryption: provider_info[:encryption]
         )
 
+        ldap_filter = Net::LDAP::Filter.eq(provider_info[:uid], user_params[:username])
+        if provider_info[:filter]
+          ldap_filter = ldap_filter & Net::LDAP::Filter.construct(provider_info[:filter])
+        end
+
         ldap.bind_as(
             base: provider_info[:base],
-            filter: "(#{provider_info[:uid]}=#{user_params[:username]})",
+            filter: ldap_filter,
             password: user_params[:password]
         )
     end


### PR DESCRIPTION
Filtering on a basedn (ie: a group) is not enough for everybody (https://github.com/bigbluebutton/greenlight/issues/439, https://github.com/bigbluebutton/greenlight/issues/1083).

This patch allows to define a custom filter.