### PR TITLE
Add login with domain name instead of dn

### DIFF
--- a/lib/bn-ldap-authentication.rb
+++ b/lib/bn-ldap-authentication.rb
@@ -18,9 +18,15 @@ module LdapAuthenticator
           method: :anonymous
       }
     when 'user'
-      auth = {
+      username = nil
+      if provider_info[:domain].present?
+        username = provider_info[:domain] + '\\' + user_params[:username]
+      else
+        username = provider_info[:uid] + '=' + user_params[:username] + ',' + provider_info[:base]
+      end
+	  auth = {
         method: :simple,
-        username: provider_info[:uid] + '=' + user_params[:username] + ',' + provider_info[:base],
+        username: username,
         password: user_params[:password]
       }
     else


### PR DESCRIPTION
Modified the behaviour of send_ldap_request to allow login with domain
and username. If provider_info[:domain] is set and auth_method is user,
this behaviour will trigger.